### PR TITLE
rust: specify the rust toolchain as nightly-2021-07-28

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2021-07-28


### PR DESCRIPTION
Signed-off-by: Xu Qiaolun <Jamesxql@Gmail.com>

fix #18 